### PR TITLE
php8

### DIFF
--- a/docker/read/Dockerfile
+++ b/docker/read/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.0.0rc1-fpm
+FROM php:8.0.0-fpm
 
-ENV PHPREDIS_VERSION 5.3.2RC2
+ENV PHPREDIS_VERSION 5.3.2
 RUN mkdir -p /usr/src/php/ext/redis \
     && curl -L https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \
     && echo 'redis' >> /usr/src/php-available-exts \


### PR DESCRIPTION
* php8-fpm的官方镜像终于出了
* 反代的前置nginx也换上了 http2